### PR TITLE
 refactor(test): clean helpers utils.test and refactor test

### DIFF
--- a/test/test-utils.js
+++ b/test/test-utils.js
@@ -1,31 +1,33 @@
-import path,{ resolve,join } from 'path';
-import { mkdir,open,mkdtemp,writeFile,rm} from 'fs/promises';
+import path, { resolve, join } from 'path';
+import { mkdir, open, mkdtemp, writeFile, rm } from 'fs/promises';
 import { pipeline } from 'stream/promises';
-import { tmpdir } from 'node:os';
+
 
 const TEST_PATH = resolve(import.meta.dirname);
-const FIXTURE_PATH = join(TEST_PATH,'fixtures');
+const FIXTURE_PATH = join(TEST_PATH, 'fixtures');
 
-async function makeTempDir(prefix = 'cpu-profiler-') {
-  const dir = await mkdtemp(path.join(tmpdir(), prefix));
-  return dir;
+async function makeTempDir(dir = 'tmp') {
+    const unique = `${dir}-${Date.now()}`;
+    const tempDir = path.join(FIXTURE_PATH,unique);
+    await mkdir(tempDir,{recursive:true});
+    return tempDir;
 }
 
-async function createFakeFile(source,dest,content = null) {
-    if(content) {
-        await mkdir(path.dirname(dest),{recursive:true});
-        await writeFile(dest,content,'utf-8');
+async function createFakeFile(source, dest, content = null) {
+    if (content) {
+        await mkdir(path.dirname(dest), { recursive: true });
+        await writeFile(dest, content, 'utf-8');
         return dest;
     }
-    await mkdir(path.dirname(dest),{recursive:true});
+    await mkdir(path.dirname(dest), { recursive: true });
 
-    const srcFile = await open(source,'r');
-    const destFile =  await open(dest,'w');
+    const srcFile = await open(source, 'r');
+    const destFile = await open(dest, 'w');
 
     try {
         const srcStream = srcFile.createReadStream();
         const destStream = destFile.createWriteStream();
-        await pipeline(srcStream,destStream);
+        await pipeline(srcStream, destStream);
         return dest;
     } catch (error) {
         throw error;
@@ -63,52 +65,45 @@ const nowNs = (n) => BigInt(Math.round(n * 1e9));
 
 
 
-async function createCpuInfo(outDir,source = '/proc/cpuinfo') {
+async function createCpuInfo(outDir, source = '/proc/cpuinfo') {
 
-    const dest = outDir ? path.join(outDir,'cpuinfo'): path.join(FIXTURE_PATH, `proc-${process.hrtime.bigint().toString()}`, 'cpuinfo');
+    const dest = outDir ? path.join(outDir, 'cpuinfo') : path.join(FIXTURE_PATH, `proc-${process.hrtime.bigint().toString()}`, 'cpuinfo');
 
-    return await createFakeFile(source,dest);
+    return await createFakeFile(source, dest);
 }
 
 async function createFakePidStatFile(pid, outDir, content) {
     const dest = path.join(outDir, String(pid), 'stat');
-    return await createFakeFile(null,dest,content);
+    return await createFakeFile(null, dest, content);
 }
 
-function generateStatSample({ pid,utime, stime, starttime, delay, hz = 100 }) {
-  const delta_ticks = Math.round(delay * hz);
-  const new_utime = utime + Math.floor(delta_ticks / 2);
-  const new_stime = stime + Math.ceil(delta_ticks / 2);
+function generateStatSample({ pid, utime, stime, starttime, delay, hz = 100 }) {
+    const delta_ticks = Math.round(delay * hz);
+    const new_utime = utime + Math.floor(delta_ticks / 2);
+    const new_stime = stime + Math.ceil(delta_ticks / 2);
 
-  const fields = [
-    pid, '(node)', 'S', 52710, 52711, 52710, 34819, 52711, 4194560,
-    18391, 0, 1, 0,
-    new_utime, new_stime, 0, 0, 20, 0, 11, 0,
-    starttime, 1278586880, 17245, '18446744073709551615', 1, 1, 0, 0, 0, 0, 0,
-    16781312, 134235650, 0, 0, 0, 17, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0
-  ];
+    const fields = [
+        pid, '(node)', 'S', 52710, 52711, 52710, 34819, 52711, 4194560,
+        18391, 0, 1, 0,
+        new_utime, new_stime, 0, 0, 20, 0, 11, 0,
+        starttime, 1278586880, 17245, '18446744073709551615', 1, 1, 0, 0, 0, 0, 0,
+        16781312, 134235650, 0, 0, 0, 17, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0
+    ];
 
-  return fields.join(' ');
+    return fields.join(' ');
 }
 
 async function createStat(outDir, source = '/proc/stat') {
-    const dest = outDir ? path.join(outDir,'stat'): path.join(FIXTURE_PATH, `proc-${process.hrtime.bigint().toString()}`, 'stat');
+    const dest = outDir ? path.join(outDir, 'stat') : path.join(FIXTURE_PATH, `proc-${process.hrtime.bigint().toString()}`, 'stat');
 
-    return await createFakeFile(source,dest);
+    return await createFakeFile(source, dest);
 }
 
-async function createFakePidFile(dir, pid) {
-    const pidFilePath = path.join(dir, 'test.pid');
-    await writeFile(pidFilePath, `${pid}\n`, 'utf-8');
-    return pidFilePath;
-}
-
-async function cleanup(testDir) {
-    if (testDir) {
-        await rm(testDir, { force: true, recursive: true });
+async function cleanup(dir) {
+    if (dir) {
+        await rm(dir, { force: true, recursive: true });
     }
 }
-
 
 /**
  * Crée un fichier /proc/stat simulé avec des ticks contrôlés.
@@ -120,22 +115,39 @@ async function cleanup(testDir) {
  * @param {number} options.idle - Ticks idle
  * @returns {Promise<string>} - Chemin du fichier stat généré
  */
- async function createStatUnderControl(
-  dir,
-  {
-    user = 1000,
-    nice = 0,
-    system = 500,
-    idle = 2000
-  } = {}
+async function createStatUnderControl(
+    dir,
+    {
+        user = 1000,
+        nice = 0,
+        system = 500,
+        idle = 2000
+    } = {}
 ) {
-  const statPath = path.join(dir, 'stat');
+    const statPath = path.join(dir, 'stat');
 
-  const cpuLine = `cpu  ${user} ${nice} ${system} ${idle} 0 0 0 0 0 0\n`;
-  const content = cpuLine + 'cpu0  ...\n'; //  ajouter des lignes de core si besoin
+    const cpuLine = `cpu  ${user} ${nice} ${system} ${idle} 0 0 0 0 0 0\n`;
+    const content = cpuLine + 'cpu0  ...\n'; //  ajouter des lignes de core si besoin
 
-  await writeFile(statPath, content, 'utf-8');
-  return statPath;
+    await writeFile(statPath, content, 'utf-8');
+    return statPath;
+}
+
+async function createPIDFile(dir, pid) {
+    const filePath = path.join(dir, 'app.pid');
+    return await writeFile(filePath, String(pid), 'utf-8');
+}
+
+
+function makeSpyLogger() {
+    const calls = { debug: [], info: [], warn: [], error: [] };
+    const logger = {
+        debug: (...a) => calls.debug.push(a),
+        info: (...a) => calls.info.push(a),
+        warn: (...a) => calls.warn.push(a),
+        error: (...a) => calls.error.push(a),
+    };
+    return { logger, calls };
 }
 
 
@@ -144,15 +156,15 @@ export {
     FIXTURE_PATH,
     makeTempDir,
     createRaplPackages,
-    nowNs,
-    setEnergy,
     createCpuInfo,
     createStat,
     createFakeFile,
     createStatUnderControl,
     createFakePidStatFile,
     generateStatSample,
-    createFakePidFile,
-    cleanup
-    
+    createPIDFile,
+    cleanup,
+    nowNs,
+    setEnergy,
+    makeSpyLogger
 }

--- a/test/unit/cpu_profiler.test.js
+++ b/test/unit/cpu_profiler.test.js
@@ -3,8 +3,8 @@ import assert from 'node:assert/strict';
 import process from 'node:process';
 import path from 'node:path';
 import SystemCpuProfiler from '../../src/sensors/cpu.js';
-import { mkdir, rm, writeFile, } from 'node:fs/promises';
-import { FIXTURE_PATH, makeTempDir, createCpuInfo, createStat, createStatUnderControl,cleanup } from '../test-utils.js';
+import { rm, writeFile, } from 'node:fs/promises';
+import { makeTempDir, createCpuInfo, createStat, createStatUnderControl,cleanup } from '../test-utils.js';
 import { cpus } from 'node:os';
 
 
@@ -17,12 +17,7 @@ export let temp;
 test('CPU PROFILER TEST SUITE', async (t) => {
 
     beforeEach(async () => {
-        // on crée un répertoire temporaire pour stocker les fichiers cpuinfo et stat
-        // on nome ce répertoire avec un timestamp pour éviter les collisions d'ecriture
-        // ou de lecture
-        // sinon {concurrency:1} dans les tests
-        temp = path.join(FIXTURE_PATH, `proc-${process.hrtime.bigint().toString()}`);
-        await mkdir(temp, { recursive: true });
+        temp = await makeTempDir('proc');
         cpuInfoFile = await createCpuInfo(temp);
         if(!process.env.CI) {
             statFile = await createStat(temp);

--- a/test/unit/host_cpu_reader.test.js
+++ b/test/unit/host_cpu_reader.test.js
@@ -1,8 +1,6 @@
 import test, { beforeEach, afterEach } from 'node:test';
 import assert from 'node:assert/strict';
-import path from 'node:path';
-import { FIXTURE_PATH, cleanup, createStatUnderControl, nowNs as generateNowNs } from '../test-utils.js';
-import { rm, mkdir } from 'node:fs/promises';
+import { cleanup, createStatUnderControl, nowNs as generateNowNs, makeTempDir } from '../test-utils.js';
 import HostCpuReader from '../../src/sensors/host_cpu_reader.js';
 import SystemCpuProfiler from '../../src/sensors/cpu.js';
 import { clampDt } from '../../src/lib/cpu_utils.js';
@@ -14,10 +12,7 @@ let temp;
 test('HOST CPU READER TEST SUITE', async (t) => {
 
     beforeEach(async () => {
-        // on crée un répertoire temporaire pour stocker les fichiers cpuinfo et stat
-        // on nome ce répertoire avec un timestamp pour éviter les collisions
-        temp = path.join(FIXTURE_PATH, `proc-${process.hrtime.bigint().toString()}`);
-        await mkdir(temp, { recursive: true });
+        temp = await makeTempDir('proc');
         statFile = await createStatUnderControl(temp, { user: 1000, system: 500, idle: 2000 });
     });
 

--- a/test/unit/pid_cpu_reader.test.js
+++ b/test/unit/pid_cpu_reader.test.js
@@ -1,29 +1,23 @@
-import test, { after, afterEach, beforeEach } from 'node:test';
+import test, { afterEach, beforeEach } from 'node:test';
 import assert from "node:assert/strict";
 import path from "node:path";
-import process from "node:process";
 import PidCpuReader from '../../src/sensors/pid_cpu_reader.js';
-import { FIXTURE_PATH, cleanup, createFakePidStatFile, generateStatSample } from '../test-utils.js';
-import { mkdir, rm } from 'node:fs/promises';
+import { cleanup, createFakePidStatFile, generateStatSample, makeTempDir } from '../test-utils.js';
 
 let pid;
 let temp;
 let statPath;
 
 test('PidCpuReader Test Suite', async (t) => {
-    // Example test: check if PidCpuReader can be instantiated
 
     beforeEach(async () => {
-        // Runs before each test
-        temp = path.join(FIXTURE_PATH, `proc-${process.hrtime.bigint().toString()}`);
-        pid = 25041; // Replace with a valid PID for testing
+        temp = await makeTempDir('proc');
+        pid = 25041;
         const statContent = generateStatSample({ pid, utime: 0, stime: 0, starttime: 9954766, delay: 0, hz: 100 });
         await createFakePidStatFile(pid, temp, statContent);
     });
 
     afterEach(async () => {
-        // Runs after all tests have completed  
-        // Clean up temporary files or directories if needed
         await cleanup(temp);
     });
 

--- a/test/unit/pid_resolver.test.js
+++ b/test/unit/pid_resolver.test.js
@@ -1,48 +1,23 @@
 import test, { beforeEach, afterEach, mock } from 'node:test';
 import assert from 'node:assert/strict';
 import { PIDResolver } from '../../src/lib/pid_resolver.js';
-import { mkdir, rm, writeFile } from 'node:fs/promises';
-import { FIXTURE_PATH } from '../test-utils.js';
+import { writeFile } from 'node:fs/promises';
+import { createPIDFile,makeSpyLogger,makeTempDir,cleanup } from '../test-utils.js';
 import path from 'node:path';
 import os from 'node:os';
 import { fork } from 'node:child_process';
 import { once } from 'node:events';
-// Utilitaire pour créer un fichier temporaire, exécuter une fonction asynchrone, puis nettoyer
-
-
-
-
 
 let temp;
-
-
-async function createPIDFile(dir, pid) {
-    const filePath = path.join(dir, 'app.pid');
-    return await writeFile(filePath, String(pid), 'utf-8');
-}
-
-
-function makeSpyLogger() {
-    const calls = { debug: [], info: [], warn: [], error: [] };
-    const logger = {
-        debug: (...a) => calls.debug.push(a),
-        info: (...a) => calls.info.push(a),
-        warn: (...a) => calls.warn.push(a),
-        error: (...a) => calls.error.push(a),
-    };
-    return { logger, calls };
-}
-
 
 test('PID RESOLVER TEST SUITE', async (t) => {
 
     beforeEach(async () => {
-        temp = path.join(FIXTURE_PATH, `pidfile-${Date.now()}`);
-        await mkdir(temp, { recursive: true });
+        temp = await makeTempDir(`pidfile`);
     });
 
     afterEach(async () => {
-        await rm(temp, { force: true, recursive: true });
+        await cleanup(temp);
     });
 
     await t.test('doit exposer une API minimale', () => {

--- a/test/unit/rapl_reader.test.js
+++ b/test/unit/rapl_reader.test.js
@@ -2,10 +2,9 @@ import assert from 'node:assert/strict';
 import test, { afterEach, beforeEach } from 'node:test';
 import path from 'node:path';
 import RaplReader from '../../src/sensors/rapl_reader.js';
-import { chmod, mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises';
-import os from 'node:os';
+import { chmod } from 'node:fs/promises';
 import { clampDt } from '../../src/lib/cpu_utils.js';
-import { nowNs, setEnergy, createRaplPackages, cleanup } from '../test-utils.js';
+import { nowNs, setEnergy, createRaplPackages, cleanup, makeTempDir } from '../test-utils.js';
 
 
 
@@ -18,9 +17,8 @@ let pkgs = [];
 test('RAPL READER TEST SUITE', async (t) => {
 
     beforeEach(async () => {
-        tmp = await mkdtemp(path.join(os.tmpdir(), 'rapl-test-'));
+        tmp = await makeTempDir('rapl-test');
         pkgs = [];
-
     });
 
     afterEach(async () => {

--- a/test/unit/runCmd.test.js
+++ b/test/unit/runCmd.test.js
@@ -1,83 +1,65 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
-import os from 'node:os';
-import { PIDResolver,runCmd } from '../../src/lib/pid_resolver.js';
-import { FIXTURE_PATH } from '../test-utils.js';
-import { mkdir,rm, writeFile} from  'node:fs/promises';
+import { PIDResolver, runCmd } from '../../src/lib/pid_resolver.js';
+import { createPIDFile,cleanup,makeSpyLogger, makeTempDir } from '../test-utils.js';
 import path from 'node:path';
 
- async function createPIDFile(dir, pid) {
-        const filePath = path.join(dir, 'app.pid');
-        return await writeFile(filePath, String(pid), 'utf-8');
-    }
-
-function makeSpyLogger() {
-  const calls = { debug: [], info: [], warn: [], error: [] };
-  return {
-    logger: {
-      debug: (...a) => calls.debug.push(a),
-      info:  (...a) => calls.info.push(a),
-      warn:  (...a) => calls.warn.push(a),
-      error: (...a) => calls.error.push(a),
-    },
-    calls,
-  };
-}
 
 test('runCmd: success simple', async () => {
-  const res = await runCmd(process.execPath, ['-e', 'console.log("ok")'], { timeoutMs: 500 }, null);
-  assert.equal(res.ok, true);
-  assert.match(res.stdout, /ok/);
-  assert.equal(res.stderr,'');
+    const res = await runCmd(process.execPath, ['-e', 'console.log("ok")'], { timeoutMs: 500 }, null);
+    assert.equal(res.ok, true);
+    assert.match(res.stdout, /ok/);
+    assert.equal(res.stderr, '');
 });
 
 
 test('runCmd: timeout', async () => {
-  const res = await runCmd(process.execPath, ['-e', 'setTimeout(()=>{}, 5000)'], { timeoutMs: 50 }, null);
-  assert.equal(res.ok, false);
-  assert.equal(res.error, 'cmd_timeout');
+    const res = await runCmd(process.execPath, ['-e', 'setTimeout(()=>{}, 5000)'], { timeoutMs: 50 }, null);
+    assert.equal(res.ok, false);
+    assert.equal(res.error, 'cmd_timeout');
 });
 
 test('runCmd: binaire introuvable', async () => {
-  const res = await runCmd('definitely-not-a-binary-xyz', [], { timeoutMs: 100 }, null);
-  assert.equal(res.ok, false);
-  assert.equal(res.error, 'tool_unavailable');
+    const res = await runCmd('definitely-not-a-binary-xyz', [], { timeoutMs: 100 }, null);
+    assert.equal(res.ok, false);
+    assert.equal(res.error, 'tool_unavailable');
 });
 
 test('runCmd: exit code non zéro', async () => {
-  const res = await runCmd(process.execPath, ['-e', 'process.exit(3)'], { timeoutMs: 500 }, null);
-  assert.equal(res.ok, false);
-  assert.equal(res.error, 'cmd_exit');
-  assert.equal(res.details.code, 3);
+    const res = await runCmd(process.execPath, ['-e', 'process.exit(3)'], { timeoutMs: 500 }, null);
+    assert.equal(res.ok, false);
+    assert.equal(res.error, 'cmd_exit');
+    assert.equal(res.details.code, 3);
 });
 
 test('runCmd: logs cmd.start/cmd.ok en succès', async () => {
-  const { logger, calls } = makeSpyLogger();
-  const res = await runCmd(process.execPath, ['-e', 'console.log("ok")'], { timeoutMs: 500 }, logger);
-  assert.equal(res.ok, true);
-  const hasStart = calls.debug.some(a => a[0] === 'cmd.start');
-  const hasOk = calls.debug.some(a => a[0] === 'cmd.ok');
-  assert.equal(hasStart && hasOk, true);
+    const { logger, calls } = makeSpyLogger();
+    const res = await runCmd(process.execPath, ['-e', 'console.log("ok")'], { timeoutMs: 500 }, logger);
+    assert.equal(res.ok, true);
+    const hasStart = calls.debug.some(a => a[0] === 'cmd.start');
+    const hasOk = calls.debug.some(a => a[0] === 'cmd.ok');
+    assert.equal(hasStart && hasOk, true);
 });
 
 test('runCmd: logs cmd.fail en erreur', async () => {
-  const { logger, calls } = makeSpyLogger();
-  const res = await runCmd(process.execPath, ['-e', 'process.exit(2)'], { timeoutMs: 500 }, logger);
-  assert.equal(res.ok, false);
-  const hasFail = calls.error.some(a => a[0] === 'cmd.fail');
-  assert.equal(hasFail, true);
+    const { logger, calls } = makeSpyLogger();
+    const res = await runCmd(process.execPath, ['-e', 'process.exit(2)'], { timeoutMs: 500 }, logger);
+    assert.equal(res.ok, false);
+    const hasFail = calls.error.some(a => a[0] === 'cmd.fail');
+    assert.equal(hasFail, true);
 });
 
 test('getProcessInfo via runCmd: retourne quelque chose pour process.pid', async () => {
-   const temp = path.join(FIXTURE_PATH, `pidfile-${Date.now()}`);
-    await mkdir(temp, { recursive: true }); 
-   await createPIDFile(temp, process.pid);
-  // Intégration indirecte : PIDResolver.resolve({returnInfo:true}) finira par appeler getProcessInfo.
-  const r = new PIDResolver({ strategy: 'file', file: path.join(temp,'app.pid'), returnInfo: true });
-  const res = await r.resolve();
-  assert.equal(res.ok, true);
-  assert.equal(res.pid, process.pid);
-  assert.ok(res.info && typeof res.info.user === 'string');
-    await rm(temp,{recursive:true,force:true});
+   // const temp = path.join(FIXTURE_PATH, `pidfile-${Date.now()}`);
+    //await mkdir(temp, { recursive: true });
+    const temp = await makeTempDir(`pidfile`);
+    await createPIDFile(temp, process.pid);
+    // Intégration indirecte : PIDResolver.resolve({returnInfo:true}) finira par appeler getProcessInfo.
+    const r = new PIDResolver({ strategy: 'file', file: path.join(temp, 'app.pid'), returnInfo: true });
+    const res = await r.resolve();
+    assert.equal(res.ok, true);
+    assert.equal(res.pid, process.pid);
+    assert.ok(res.info && typeof res.info.user === 'string');
+    await cleanup(temp);
 });
 


### PR DESCRIPTION
This PR  clean helpers functions in utils.test , and refactor all test 
we also  updates the `name` constraint logic to support both `node` and `MainThread` as valid process names in pidresolver class
Ensures compatibility with Node.js 24 and CI environments.
All tests pass locally and in CI.